### PR TITLE
Script matches any string starting with an alias

### DIFF
--- a/src/alias.coffee
+++ b/src/alias.coffee
@@ -48,6 +48,6 @@ module.exports = (robot) ->
   # Compile RegEx to match only the aliases
   # Note this matches (alias) :alias: and @alias
   aliases = _.keys(groups).join('|')
-  regex = new RegExp('((?:\\(|\\:|@)(' + aliases + ')(?:\\|\\:)*)', 'i')
+  regex = new RegExp('(?:@(' + aliases + ')\\b)|(?:\\(|\\:)(' + aliases + ')(?:\\)|\\:)', 'i')
   robot.hear regex, (msg) ->
     msg.send expand(msg.message.text)


### PR DESCRIPTION
We're using this script at work. A few weeks ago we added a pretty short group alias (`po`), then we realised the script is matching any string delimited by @, : : and ( ) that starts with a group alias. You can try by running a hubot console:

```
$ HUBOT_GROUP_ALIAS="po=louis,martha;infra=john,stephen,thomas" bin/hubot
Hubot> :poolparty:
Hubot> :poolparty:

Hubot> @poolparty
Hubot> @louis @marthaolparty

Hubot> (poolparty)
Hubot> (poolparty)
```

Each second line is a Hubot response. You can see it is treating ``poolparty`` as an alias, when it is not.

After applying this patch this is how the script behaves:

```
$ HUBOT_GROUP_ALIAS="po=louis,martha;infra=john,stephen,thomas" bin/hubot
Hubot> :poolparty:
Hubot> @poolparty
Hubot> (poolparty)

Hubot> :po:
Hubot> @louis @martha

Hubot> @po
Hubot> @louis @martha

Hubot> @infra
Hubot> @john @stephen @thomas

Hubot> (infra)
Hubot> @john @stephen @thomas

Hubot> (nogroup)
```

As you can see in the first three lines ``poolparty`` no longer matches and so hubot does not reply.

Note: As you can see I'm not that much of a regex ninja. There may be a better regex to fix this. However, I think this one works as I would expect.

What do you think about fixing this? Would you merge this patch?